### PR TITLE
Fix regression fetch utxo bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,11 +275,13 @@ pub extern "C" fn create_and_sign_transaction(
         TransactionType::Claim => LBtcSwapTx::new_claim(
             swap_script.clone(),
             onchain_address_str.to_string(),
+            tx_str.to_string(),
             network_config,
         ),
         TransactionType::Refund => LBtcSwapTx::new_refund(
             swap_script.clone(),
             onchain_address_str.to_string(),
+            tx_str.to_string(),
             network_config,
         ),
     };

--- a/src/network/electrum.rs
+++ b/src/network/electrum.rs
@@ -5,8 +5,8 @@ use crate::error::Error;
 use super::Chain;
 
 pub const DEFAULT_TESTNET_NODE: &str = "electrum.bullbitcoin.com:60002";
-pub const DEFAULT_LIQUID_TESTNET_NODE: &str = "blockstream.info:995";
-pub const DEFAULT_MAINNET_NODE: &str = "blockstream.info:995";
+pub const DEFAULT_LIQUID_TESTNET_NODE: &str = "blockstream.info:465";
+pub const DEFAULT_MAINNET_NODE: &str = "electrum.blockstream.info:50002";
 pub const DEFAULT_ELECTRUM_TIMEOUT: u8 = 10;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This was a regression upstream or a bug that was never truly fixed. 

What they're doing is they're fetching the lockup tx from electrum by querying with the redeemScript. This wasn't working back in February, and so I decided to just pass the lockup tx to rust from dart since we could get it from boltz easily.

When I rebased/re-made our fork onto their code early March then I did away with this fix of passing the lockup tx from dart to rust, and went back to depending on their "fetch lockup tx from electrum with redeemScript" method. I suppose they somewhat fixed this, as it seemed to work most of the time. But not all.

So this fix is reverting back to me passing the lockup tx from dart (where we fetch it from boltz) directly to rust.